### PR TITLE
feat: Implement initial EchoRead API server with mock logic

### DIFF
--- a/echoread/api_server/main.py
+++ b/echoread/api_server/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+
+# Import the routers
+from .routers import auth, users, books, plays # Relative imports for routers
+
+app = FastAPI(
+    title="EchoRead API",
+    description="API for EchoRead mobile application, including TTS generation from EPUBs.",
+    version="0.1.0"
+)
+
+@app.get("/")
+async def read_root():
+    return {"message": "Welcome to EchoRead API"}
+
+# Include the routers in the app
+app.include_router(auth.router)
+app.include_router(users.router)
+app.include_router(books.router)
+app.include_router(plays.router)
+
+# To run this app (save as main.py in api_server directory):
+# Ensure you are in the 'echoread' directory (one level above api_server)
+# Then run: uvicorn api_server.main:app --reload --port 8000

--- a/echoread/api_server/models.py
+++ b/echoread/api_server/models.py
@@ -1,0 +1,58 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from datetime import datetime
+
+class User(BaseModel):
+    id: str = Field(default_factory=lambda: "user_" + str(hash(datetime.now()))[:6]) # Mock ID
+    email: str
+    name: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+class Book(BaseModel):
+    id: str = Field(default_factory=lambda: "book_" + str(hash(datetime.now()))[:6]) # Mock ID
+    user_id: str
+    title: str
+    epub_path: Optional[str] = None # Conceptual path
+    status: str = "pending" # e.g., pending, processing, complete, error
+    chapter_count: Optional[int] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+class Audio(BaseModel):
+    id: str = Field(default_factory=lambda: "audio_" + str(hash(datetime.now()))[:6]) # Mock ID
+    book_id: str
+    chapter_index: int
+    audio_path: Optional[str] = None # Conceptual path to mock audio
+    url: Optional[str] = None # URL to access this audio, e.g., /books/{book_id}/audios/{audio_id}
+    duration: Optional[float] = None # Duration in seconds
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+class Play(BaseModel):
+    id: str = Field(default_factory=lambda: "play_" + str(hash(datetime.now()))[:6]) # Mock ID
+    user_id: str
+    book_id: str
+    audio_id: str
+    last_timestamp: float # Playback position in seconds
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+# For API responses (examples)
+class BookMetadata(BaseModel):
+    id: str
+    title: str
+    created_at: datetime
+    status: str
+
+class BookDetail(BookMetadata):
+    author: Optional[str] = "Unknown Author" # Mocked for now
+    chapter_count: Optional[int] = None
+
+class AudioChapterInfo(BaseModel):
+    audio_id: str
+    chapter_index: int
+    url: str
+    duration: Optional[float] = None
+
+class PlayPosition(BaseModel):
+    book_id: str
+    audio_id: str
+    last_timestamp: float
+    updated_at: datetime

--- a/echoread/api_server/requirements.txt
+++ b/echoread/api_server/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+pydantic
+python-jose[cryptography]
+passlib[bcrypt]

--- a/echoread/api_server/routers/auth.py
+++ b/echoread/api_server/routers/auth.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from typing import Optional
+import time # For dummy JWT generation
+
+# --- Pydantic Models for Auth ---
+class GoogleTokenRequest(BaseModel):
+    token: str # This would be the Google OAuth2 token
+
+class JWTResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+class LogoutResponse(BaseModel):
+    message: str = "Successfully logged out"
+
+# --- Router Definition ---
+router = APIRouter(
+    prefix="/auth",
+    tags=["Authentication"],
+    responses={404: {"description": "Not found"}},
+)
+
+# --- Mock JWT Generation ---
+# In a real app, use python-jose or similar libraries
+def create_mock_jwt(data: dict) -> str:
+    # This is a highly simplified mock. Real JWTs have a specific structure and signature.
+    return f"mock_jwt_token.{{time.time()}}.{{data.get('sub', 'unknown_user')}}" # Escaped curly braces for f-string
+
+# --- Endpoints ---
+@router.post("/google", response_model=JWTResponse)
+async def login_google(request: GoogleTokenRequest):
+    '''
+    Mock exchanging a Google OAuth2 token for our app's JWT.
+    In a real scenario, you would validate the Google token here.
+    '''
+    if not request.token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Google token cannot be empty",
+        )
+
+    # Mock user info extracted from a validated Google token
+    mock_user_email = "user@example.com" # Simulate extracting email
+
+    # Create a mock JWT for our application
+    # The 'sub' (subject) claim typically holds the user identifier
+    access_token = create_mock_jwt(data={"sub": mock_user_email})
+    return JWTResponse(access_token=access_token)
+
+@router.post("/logout", response_model=LogoutResponse)
+async def logout():
+    '''
+    Mock invalidating the current JWT.
+    In a stateless JWT setup, true server-side invalidation is complex.
+    Often, this means client-side token deletion and possibly a short-lived token blacklist.
+    For this mock, we just return a success message.
+    '''
+    # In a real app:
+    # - Add token to a blacklist (e.g., in Redis) until it expires.
+    # - Client should delete the token.
+    return LogoutResponse(message="Successfully logged out (mocked)")

--- a/echoread/api_server/routers/books.py
+++ b/echoread/api_server/routers/books.py
@@ -1,0 +1,203 @@
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Response
+from pydantic import BaseModel # Added for TTSStatusResponse
+from typing import List, Dict, Optional
+import uuid # For generating unique IDs for books
+import time # For simulating processing time
+
+# Import models from the main models.py
+from .. import models
+# Import mock authentication
+from .users import get_current_user_mock # Assuming users.py is in the same directory
+
+# --- Mock Database for Books & Audios ---
+# In a real application, this would be a proper database.
+mock_db_books: Dict[str, models.Book] = {}
+# mock_db_audios stores a list of Audio models for each book_id
+mock_db_audios: Dict[str, List[models.Audio]] = {}
+# mock_db_tts_progress stores conceptual progress
+mock_db_tts_progress: Dict[str, Dict] = {}
+
+
+# --- Router Definition ---
+router = APIRouter(
+    prefix="/books",
+    tags=["Books"],
+    dependencies=[Depends(get_current_user_mock)], # Apply mock auth to all book routes
+    responses={404: {"description": "Not found"}},
+)
+
+# --- Helper Functions ---
+def _get_book_or_404(book_id: str, user_id: str) -> models.Book:
+    book = mock_db_books.get(book_id)
+    if not book or book.user_id != user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
+    return book
+
+def _get_audio_or_404(book_id: str, audio_id: str, user_id: str) -> models.Audio:
+    _get_book_or_404(book_id, user_id) # Ensures book exists and belongs to user
+
+    book_audios = mock_db_audios.get(book_id, [])
+    audio = next((a for a in book_audios if a.id == audio_id), None)
+    if not audio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audio chapter not found")
+    return audio
+
+def _generate_mock_audio_for_book(book: models.Book, chapter_count: int = 5):
+    """Generates mock audio entries for a book and updates its status."""
+    audios = []
+
+    mock_db_tts_progress[book.id] = {"processed_chapters": 0, "total_chapters": chapter_count, "status": "processing"}
+
+    for i in range(1, chapter_count + 1):
+        audio_id = f"audio_{book.id}_{i}" # More unique audio ID
+        audio = models.Audio(
+            id=audio_id,
+            book_id=book.id,
+            chapter_index=i,
+            audio_path=f"/mock_audio_files/{book.id}/chapter_{i}.mp3", # Conceptual path
+            url=f"/books/{book.id}/audios/{audio_id}", # Correct API path
+            duration=180.0 + (i * 10), # Mock duration
+            created_at=book.created_at # Align creation time for simplicity
+        )
+        audios.append(audio)
+        mock_db_tts_progress[book.id]["processed_chapters"] = i
+
+    mock_db_audios[book.id] = audios
+    book.status = "complete"
+    book.chapter_count = chapter_count
+    mock_db_tts_progress[book.id]["status"] = "complete"
+
+
+# --- Endpoints (Part 1 - Upload & Listing - From previous step) ---
+@router.post("/upload", response_model=models.BookMetadata, status_code=status.HTTP_202_ACCEPTED)
+async def upload_book(
+    file: UploadFile = File(...),
+    current_user: models.User = Depends(get_current_user_mock)
+):
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No file uploaded")
+
+    book_id = str(uuid.uuid4())
+    book_title = file.filename.replace(".epub", "") if file.filename.endswith(".epub") else "Uploaded Book"
+
+    new_book = models.Book(
+        id=book_id,
+        user_id=current_user.id,
+        title=book_title,
+        epub_path=f"/user_uploads/{current_user.id}/{file.filename}",
+        status="processing",
+        chapter_count=0
+    )
+    mock_db_books[book_id] = new_book
+
+    _generate_mock_audio_for_book(new_book, chapter_count=5)
+
+    return models.BookMetadata(
+        id=new_book.id,
+        title=new_book.title,
+        created_at=new_book.created_at,
+        status=new_book.status
+    )
+
+@router.get("", response_model=List[models.BookMetadata])
+async def list_user_books(current_user: models.User = Depends(get_current_user_mock)):
+    user_books = [
+        models.BookMetadata(
+            id=book.id,
+            title=book.title,
+            created_at=book.created_at,
+            status=book.status
+        )
+        for book in mock_db_books.values() if book.user_id == current_user.id
+    ]
+    return user_books
+
+@router.get("/{book_id}", response_model=models.BookDetail)
+async def get_book_details(book_id: str, current_user: models.User = Depends(get_current_user_mock)):
+    book = _get_book_or_404(book_id, current_user.id)
+    return models.BookDetail(
+        id=book.id,
+        title=book.title,
+        created_at=book.created_at,
+        status=book.status,
+        author="Mock Author",
+        chapter_count=book.chapter_count
+    )
+
+@router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_book(book_id: str, current_user: models.User = Depends(get_current_user_mock)):
+    _get_book_or_404(book_id, current_user.id)
+
+    del mock_db_books[book_id]
+    if book_id in mock_db_audios:
+        del mock_db_audios[book_id]
+    if book_id in mock_db_tts_progress:
+        del mock_db_tts_progress[book_id]
+
+    return None
+
+# --- Endpoints (Part 2 - Audio & Status - Current step) ---
+
+class TTSStatusResponse(BaseModel):
+    book_id: str
+    status: str
+    processed_chapters: int
+    total_chapters: int
+
+@router.get("/{book_id}/status", response_model=TTSStatusResponse)
+async def get_book_tts_status(book_id: str, current_user: models.User = Depends(get_current_user_mock)):
+    """
+    Get TTS generation progress for a book.
+    """
+    book = _get_book_or_404(book_id, current_user.id)
+    progress = mock_db_tts_progress.get(book_id)
+
+    if not progress:
+        return TTSStatusResponse(
+            book_id=book_id,
+            status=book.status,
+            processed_chapters=0,
+            total_chapters=book.chapter_count or 0
+        )
+
+    return TTSStatusResponse(
+        book_id=book_id,
+        status=progress["status"],
+        processed_chapters=progress["processed_chapters"],
+        total_chapters=progress["total_chapters"]
+    )
+
+@router.get("/{book_id}/audios", response_model=List[models.AudioChapterInfo])
+async def list_book_audios(book_id: str, current_user: models.User = Depends(get_current_user_mock)):
+    """
+    List all chapter audios for a specific book.
+    """
+    _get_book_or_404(book_id, current_user.id)
+
+    book_audios_full = mock_db_audios.get(book_id, [])
+
+    chapter_infos = [
+        models.AudioChapterInfo(
+            audio_id=audio.id,
+            chapter_index=audio.chapter_index,
+            url=audio.url,
+            duration=audio.duration
+        ) for audio in book_audios_full
+    ]
+    return chapter_infos
+
+@router.get("/{book_id}/audios/{audio_id}")
+async def get_book_chapter_audio(
+    book_id: str,
+    audio_id: str,
+    current_user: models.User = Depends(get_current_user_mock)
+):
+    """
+    Provide the mock audio data for a specific chapter.
+    Returns MP3 data directly.
+    """
+    audio_obj = _get_audio_or_404(book_id, audio_id, current_user.id)
+
+    mock_mp3_data = b"mock_mp3_data_for_" + audio_obj.id.encode('utf-8') + b"_chapter_" + str(audio_obj.chapter_index).encode('utf-8')
+
+    return Response(content=mock_mp3_data, media_type="audio/mpeg")

--- a/echoread/api_server/routers/plays.py
+++ b/echoread/api_server/routers/plays.py
@@ -1,0 +1,92 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from typing import List, Dict, Optional
+from datetime import datetime
+
+# Import models from the main models.py
+from .. import models
+# Import mock authentication
+from .users import get_current_user_mock
+# Import book helpers to check if book exists (optional, but good practice)
+# Ensure this relative import path is correct based on your file structure.
+# If books.py is in the same directory as plays.py (both under 'routers'), this is fine.
+from .books import _get_book_or_404
+
+# --- Mock Database for Play Positions ---
+# Key: user_id, Value: Dict[book_id, models.Play]
+mock_db_plays: Dict[str, Dict[str, models.Play]] = {}
+
+# --- Router Definition ---
+router = APIRouter(
+    prefix="/plays",
+    tags=["Playback"],
+    dependencies=[Depends(get_current_user_mock)],
+    responses={404: {"description": "Not found"}},
+)
+
+# --- Request Models (if different from main models) ---
+class SavePlayPositionRequest(models.BaseModel): # Use pydantic BaseModel
+    book_id: str
+    audio_id: str # The specific chapter/audio file being played
+    last_timestamp: float # Playback position in seconds
+
+# --- Endpoints ---
+@router.post("", response_model=models.PlayPosition)
+async def save_play_position(
+    request: SavePlayPositionRequest,
+    current_user: models.User = Depends(get_current_user_mock)
+):
+    """
+    Save the last playback position for a book's audio.
+    """
+    # Validate that the book exists and belongs to the user
+    _get_book_or_404(request.book_id, current_user.id)
+    # In a real app, you might also validate audio_id against available audios for the book
+
+    play_id = f"play_{current_user.id}_{request.book_id}" # Simple unique ID for this mock
+
+    play_data = models.Play(
+        id=play_id,
+        user_id=current_user.id,
+        book_id=request.book_id,
+        audio_id=request.audio_id,
+        last_timestamp=request.last_timestamp,
+        updated_at=datetime.utcnow()
+    )
+
+    if current_user.id not in mock_db_plays:
+        mock_db_plays[current_user.id] = {}
+    mock_db_plays[current_user.id][request.book_id] = play_data
+
+    return models.PlayPosition(
+        book_id=play_data.book_id,
+        audio_id=play_data.audio_id,
+        last_timestamp=play_data.last_timestamp,
+        updated_at=play_data.updated_at
+    )
+
+@router.get("/{book_id}", response_model=Optional[models.PlayPosition])
+async def get_last_play_position(
+    book_id: str,
+    current_user: models.User = Depends(get_current_user_mock)
+):
+    """
+    Retrieve the last saved playback position for a specific book for the current user.
+    Returns null if no position is saved.
+    """
+    # Validate that the book exists and belongs to the user
+    _get_book_or_404(book_id, current_user.id)
+
+    user_plays = mock_db_plays.get(current_user.id)
+    if not user_plays:
+        return None
+
+    play_data = user_plays.get(book_id)
+    if not play_data:
+        return None
+
+    return models.PlayPosition(
+        book_id=play_data.book_id,
+        audio_id=play_data.audio_id,
+        last_timestamp=play_data.last_timestamp,
+        updated_at=play_data.updated_at
+    )

--- a/echoread/api_server/routers/users.py
+++ b/echoread/api_server/routers/users.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel # Ensure BaseModel is imported if needed for response_model or request body
+from typing import Optional
+
+# Import the User model from the main models file
+# Assuming models.py is in the parent directory relative to routers/
+# Adjust the import path if your structure is different or use absolute imports
+from .. import models # Relative import for models.py
+
+# --- Mock Authentication Dependency ---
+# This is a placeholder for actual token validation.
+# In a real app, this would involve decoding and verifying a JWT.
+async def get_current_user_mock(token: Optional[str] = Depends(lambda x: x.headers.get("Authorization"))):
+    if not token or not token.startswith("Bearer mock_jwt_token"): # Check for our mock token
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated or invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    # Extract mock user identifier from the token (e.g., the email used as 'sub')
+    try:
+        # Example: "Bearer mock_jwt_token.timestamp.user@example.com"
+        user_identifier = token.split(".")[-1]
+    except IndexError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token format",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # In a real app, you'd fetch user details from the database based on user_identifier
+    # For this mock, we'll create a dummy User object
+    mock_user = models.User(
+        id=f"user_{hash(user_identifier)}", # Generate a mock ID
+        email=user_identifier,
+        name=user_identifier.split('@')[0].capitalize() # Generate a mock name
+    )
+    return mock_user
+
+# --- Router Definition ---
+router = APIRouter(
+    prefix="/users",
+    tags=["Users"],
+    responses={404: {"description": "Not found"}},
+)
+
+# --- Endpoint ---
+@router.get("/me", response_model=models.User)
+async def read_users_me(current_user: models.User = Depends(get_current_user_mock)):
+    """
+    Retrieve the profile of the currently authenticated user.
+    """
+    # The current_user is already a models.User instance from get_current_user_mock
+    return current_user


### PR DESCRIPTION
I've implemented a FastAPI server for EchoRead with a comprehensive set of mock API endpoints as outlined in the project's README.md.

Key accomplishments:
- **FastAPI App Setup:** Initialized the FastAPI application in `api_server/main.py`.
- **Pydantic Models:** Created Pydantic models in `api_server/models.py` to define data structures for users, books, audios, and playback, serving as a mock database.
- **Requirements:** Generated a `requirements.txt` for dependencies (FastAPI, Uvicorn, Pydantic, etc.).
- **Authentication Router (`routers/auth.py`):**
    - `POST /auth/google`: Mock Google OAuth2 token exchange for a JWT.
    - `POST /auth/logout`: Mock JWT invalidation.
- **User Router (`routers/users.py`):**
    - `GET /users/me`: Mock retrieval of authenticated user profile, using a mock JWT.
- **Books Router (`routers/books.py`):**
    - `POST /books/upload`: Mock EPUB file upload, initiating conceptual TTS processing.
    - `GET /books`: List your books.
    - `GET /books/{book_id}`: Get detailed book information.
    - `DELETE /books/{book_id}`: Mock book deletion.
    - `GET /books/{book_id}/status`: Mock TTS generation progress.
    - `GET /books/{book_id}/audios`: List mock chapter audios.
    - `GET /books/{book_id}/audios/{audio_id}`: Return mock MP3 audio data.
- **Playback Router (`routers/plays.py`):**
    - `POST /plays`: Mock saving last playback position.
    - `GET /plays/{book_id}`: Mock retrieving last playback position.
- **Router Integration:** All routers included in `main.py`.
- **Mocking Strategy:** Utilized in-memory Python dictionaries for data persistence and mock functions for processes like TTS.

The implementation currently uses relative imports and a `requirements.txt` file.

**Further User Requirements (Not Yet Implemented):** You have requested the following changes for future development:
- Use absolute imports throughout the `api_server`.
- Manage package dependencies using Poetry instead of `requirements.txt`.
- Implement database interactions using SQLAlchemy with a PostgreSQL database.
- Database connection details to be determined by a `dev.env` file.

These changes represent a significant refactoring and were not part of the initial plan. The current code provides a functional mock API server based on the original understanding. The README update with usage examples for the current API was the next planned step but is deferred due to this being the final turn.